### PR TITLE
Directly call syscall(SYS_getpid) instead of getpid() in syscall test

### DIFF
--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -28,6 +28,7 @@ char SCCSid[] = "@(#) @(#)syscall.c:3.3 -- 5/15/91 19:30:21";
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/syscall.h>
 #include "timeit.c"
 
 unsigned long iter;
@@ -65,7 +66,7 @@ char	*argv[];
         case 'm':
 	   while (1) {
 		close(dup(0));
-		getpid();
+		syscall(SYS_getpid);
 		getuid();
 		umask(022);
 		iter++;
@@ -79,7 +80,7 @@ char	*argv[];
            /* NOTREACHED */
         case 'g':
            while (1) {
-                getpid();
+                syscall(SYS_getpid);
                 iter++;
            }
            /* NOTREACHED */


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man2/getpid.2.html:

> From glibc version 2.3.4 up to and including version 2.24, the glibc
wrapper function for getpid() cached PIDs, with the goal of avoiding
additional system calls when a process calls getpid() repeatedly.

So it's not suitable to messure the system call performance through
getpid(). Directly call syscall(SYS_getpid) is more appropriate.

From glibc version 2.25, cached pid is removed to fix some bugs which
makes the testsuite wrongly report performance regression on system call.

Same issue is reported to unixbench upstream long time ago, but nobody
cares. https://github.com/kdlucas/byte-unixbench/pull/58

Signed-off-by: Yuanhong Peng <yummypeng@linux.alibaba.com>